### PR TITLE
Added stall_warnings parameter support to sample()

### DIFF
--- a/tweepy/streaming.py
+++ b/tweepy/streaming.py
@@ -409,13 +409,15 @@ class Stream(object):
         self.url = '/%s/statuses/retweet.json' % STREAM_VERSION
         self._start(async)
 
-    def sample(self, async=False, languages=None):
+    def sample(self, async=False, languages=None, stall_warnings=False):
         self.session.params = {'delimited': 'length'}
         if self.running:
             raise TweepError('Stream object already connected!')
         self.url = '/%s/statuses/sample.json' % STREAM_VERSION
         if languages:
             self.session.params['language'] = ','.join(map(str, languages))
+        if stall_warnings:
+            self.session.params['stall_warnings'] = 'true'
         self._start(async)
 
     def filter(self, follow=None, track=None, async=False, locations=None,


### PR DESCRIPTION
Currently the stall_warnings parameter is unavailable for the sample endpoint.
